### PR TITLE
Fix botany grape seed config to use correct block

### DIFF
--- a/kubejs/data/botanytrees/recipes/vinery/red_grape_seeds.json
+++ b/kubejs/data/botanytrees/recipes/vinery/red_grape_seeds.json
@@ -16,7 +16,7 @@
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "vinery:red_grape_seeds"
+      "block": "vinery:red_grape_bush"
     },
     "drops": [
       {

--- a/kubejs/data/botanytrees/recipes/vinery/white_grape_seeds.json
+++ b/kubejs/data/botanytrees/recipes/vinery/white_grape_seeds.json
@@ -16,7 +16,7 @@
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "vinery:white_grape_seeds"
+      "block": "vinery:white_grape_bush"
     },
     "drops": [
       {


### PR DESCRIPTION
Fixes error from previous pull request - was attempting to use an item for the block display.