### PR TITLE
startserver.sh follows HTTP 302 Found for serverstarter.jar when using curl

### DIFF
--- a/server_files/startserver.sh
+++ b/server_files/startserver.sh
@@ -27,7 +27,7 @@ fi
 			which curl >> /dev/null
 			if [ $? -eq 0 ]; then
 				echo "DEBUG: (curl) Downloading ${URL}"
-				curl -o serverstarter-2.4.0.jar "${URL}"
+				curl -Lo serverstarter-2.4.0.jar "${URL}"
 			else
 				echo "Neither wget or curl were found on your system. Please install one and try again"
          fi


### PR DESCRIPTION
Given wget is not available and curl is available, when startserver.sh is executed, then it downloads a 0 byte serverstarter-2.4.0.jar. This is because GitHub returns 0 length 302 Found HTTP response for this URL. Adding the -L flag to curl command will follow GitHub's redirect to the actual file.