### PR TITLE
Add MineCells elevator to entity culling whitelist

### DIFF
--- a/config/entityculling.json
+++ b/config/entityculling.json
@@ -10,7 +10,7 @@
     "create:gantry_carriage"
   ],
   "entityWhitelist": [
-    "botania:mana_burst", "create:gantry_carriage"
+    "botania:mana_burst", "create:gantry_carriage", "minecells:elevator"
   ],
   "tracingDistance": 128,
   "debugMode": false,


### PR DESCRIPTION
As per the Minecells Developers info, Minecells Elevators will be culled out of render distance and fail to render back in again when called over long distances. This fixes this problem.

I have tested this change on my own client on AOF6 1.3.0 with multiple elevators and all worked fine.

![image](https://user-images.githubusercontent.com/1773445/217682293-dda8820f-1554-4293-ad4f-fec2e0741f48.png)
