### PR TITLE
Mining Gadgets Charge > 1M

### DIFF
--- a/config/mininggadgets-common.toml
+++ b/config/mininggadgets-common.toml
@@ -60,5 +60,5 @@
 		baseCost = 200
 		#Maximum power for the Mining Gadget
 		#Range: > 0
-		maxPower = 1000000
+		maxPower = 10000000
 


### PR DESCRIPTION
This fixes mining gadgets not charging past 1M even if your battery upgrades are in the gadget. 10M is max with the best tier battery upgrade.

Tested on AOF6 1.3.0

![image](https://user-images.githubusercontent.com/1773445/217856520-b4f0b856-893a-4c00-a1ed-f68404fc564c.png)
