### PR TITLE
Make chiselled bits a collapsible entry in REI.

### DIFF
--- a/kubejs/client_scripts/collapsed_entries.js
+++ b/kubejs/client_scripts/collapsed_entries.js
@@ -1,0 +1,4 @@
+REIEvents.groupEntries(event => {
+    const block_bit = Item.of('chiselsandbits:block_bit')
+    event.groupSameItem('kubejs:rei_groups/chiselsandbits/block_bit', 'Chiselled bits', block_bit)
+});


### PR DESCRIPTION
^_^

Usually scripts have an array for what to act on but I can't see any other block with 1000s of entries.

Preview (closed):
![image](https://user-images.githubusercontent.com/5214513/218050287-f2cfbfdc-cb0d-4b25-af20-5b603f9c91da.png)
Preview (open):
![image](https://user-images.githubusercontent.com/5214513/218050402-7fb0965d-b471-4718-8cec-90bc693ea785.png)
