### PR TITLE
Fix missing #!/bin/bash on start script

### DIFF
--- a/server_files/startserver.sh
+++ b/server_files/startserver.sh
@@ -1,4 +1,6 @@
-﻿DO_RAMDISK=0
+#!/bin/bash
+
+DO_RAMDISK=0
 if [[ $(cat server-setup-config.yaml | grep 'ramDisk:' | awk 'BEGIN {FS=":"}{print $2}') =~ "yes" ]]; then
     SAVE_DIR=$(cat server.properties | grep 'level-name' | awk 'BEGIN {FS="="}{print $2}')
     mv $SAVE_DIR "${SAVE_DIR}_backup"


### PR DESCRIPTION
Missing this line causes problems using the script in some environments. Adding this resolves any possible conflicts with the system trying to run with other shells or the native sh.