### PR TITLE
Fix #164: Make the Cryo Freezer much more useful

### DIFF
--- a/config/ad_astra.jsonc
+++ b/config/ad_astra.jsonc
@@ -132,7 +132,7 @@
     },
     "cryoFreezer": {
         "maxEnergy": 30000,
-        "energyPerTick": 243000,
+        "energyPerTick": 18,
         "tankSize": 243000
     }
 }


### PR DESCRIPTION
The Cryo Freezer was set to use much more power than it could accept, rendering it useless and rendering Cryo Fuel unobtainable.

The power requirement is lowered massively, from 243,000 EU/t to the default of 18 EU/t, allowing it to be powered by a single Modern Industrialization steam turbine.