### PR TITLE
Fix BYG bookshelves not working for enchanting

### DIFF
--- a/kubejs/server_scripts/tags/general.js
+++ b/kubejs/server_scripts/tags/general.js
@@ -56,4 +56,17 @@ ServerEvents.tags('block', event => {
   //fix BYG bookshelves not working for enchanting
   event.add('chipped:bookshelf', /^byg:.+_bookshelf$/)
 
+  // AE2 growth accelerator support for additional budding blocks
+  const budding_blocks = [
+    'byg:budding_ametrine_ore',
+    'byg:budding_subzero_crystal',
+    'byg:budding_therium_crystal',
+    'spectrum:budding_topaz',
+    'spectrum:budding_citrine',
+    'spectrum:budding_onyx'
+  ];
+
+  budding_blocks.forEach((block) => {
+    event.add('c:budding_blocks', block)
+  });
 });

--- a/kubejs/server_scripts/tags/general.js
+++ b/kubejs/server_scripts/tags/general.js
@@ -53,4 +53,7 @@ ServerEvents.tags('block', event => {
   // Graves fix
   event.add('minecells:conjunctivius_unbreakable', 'yigd:grave')
 
+  //fix BYG bookshelves not working for enchanting
+  event.add('chipped:bookshelf', /^byg:.+_bookshelf$/)
+
 });


### PR DESCRIPTION
The #chipped:bookshelf tag seems to be required for bookshelves to work for the enchanting table and Spell Engine spell binding table.

Does not work for the Bookshelf Traveler's Backpack, which still won't provide enchanting power when turned on.

Didn't include the Twilight Forest canopy bookshelf since it seems to have double enchanting power. Not sure if that's intended behavior.