### PR TITLE
Added Supplementaries Cage to the replicator_blacklist.js

### DIFF
--- a/kubejs/server_scripts/tags/replicator_blacklist.js
+++ b/kubejs/server_scripts/tags/replicator_blacklist.js
@@ -203,6 +203,7 @@ ServerEvents.tags('item', event => {
 	    '#supplementaries:trapped_presents',
         'kibe:cooler',
         'supplementaries:safe',
+	'supplementaries:cage',
         'create:chest_minecart_contraption',
         'create:furnace_minecart_contraption',
         'create:minecart_contraption',


### PR DESCRIPTION
This fixes the exploit with Supplementaries cages allowing you to replicate any item