### PR TITLE
Remove uncraftable Create blocks from the Create lootbags

### DIFF
--- a/kubejs/data/aof/loot_tables/loot_bags/create_common.json
+++ b/kubejs/data/aof/loot_tables/loot_bags/create_common.json
@@ -106,17 +106,6 @@
         {
           "type": "minecraft:item",
           "weight": 1,
-          "name": "create:andesite_encased_large_cogwheel",
-          "functions": [
-            {
-              "count": 2,
-              "function": "set_count"
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
           "name": "create:goggles",
           "functions": [
             {

--- a/kubejs/data/aof/loot_tables/loot_bags/create_epic.json
+++ b/kubejs/data/aof/loot_tables/loot_bags/create_epic.json
@@ -40,17 +40,6 @@
         {
           "type": "minecraft:item",
           "weight": 1,
-          "name": "create:brass_encased_shaft",
-          "functions": [
-            {
-              "count": 4,
-              "function": "set_count"
-            }
-          ]
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
           "name": "create:brass_ingot",
           "functions": [
             {


### PR DESCRIPTION
The brass encased shaft and brass encased large cogwheel aren't craftable, they're created by using a casing onto a shaft/cogwheel. This PR removes those uncraftable blocks from the loot bag tables