### PR TITLE
Update Botanias default config

### DIFF
--- a/config/botania-client.json5
+++ b/config/botania-client.json5
@@ -1,5 +1,7 @@
 {
 	"rendering": {
+		// Set this to false to disable the use of shaders for some of the mod's renders. (Requires game restart)
+		"shaders": true,
 		// Set this to false to disable the wireframe when looking a block bound to something (spreaders, flowers, etc).
 		"boundBlockWireframe": true,
 		// Set this to false to disable rendering of accessories in the player.


### PR DESCRIPTION
The latest version of Botania that AoF6 uses has the option to disable Botania shaders. The default configuration does not include this setting.